### PR TITLE
Handles multiple Unpaywall files

### DIFF
--- a/unpaywall_test.go
+++ b/unpaywall_test.go
@@ -25,6 +25,20 @@ func TestUnpaywall(t *testing.T) {
 				Source:                "Unpaywall",
 				Name:                  "Nanometer-Scale Thermometry.pdf",
 			},
+			{
+				Location:              "http://europepmc.org/articles/pmc4221854?pdf=render",
+				RepositoryInstitution: "pubmedcentral.nih.gov",
+				Type:                  "application/pdf",
+				Source:                "Unpaywall",
+				Name:                  "pmc4221854?pdf=render",
+			},
+			{
+				Location:              "http://arxiv.org/pdf/1304.1068",
+				RepositoryInstitution: "arXiv.org",
+				Type:                  "application/pdf",
+				Source:                "Unpaywall",
+				Name:                  "1304.1068",
+			},
 		},
 	}
 


### PR DESCRIPTION
- the initial draft of this service included support for multiple files
- while at first we scoped back the mvp, after further discussion about what we want to include in mvp it was determined that multiple file support is preferred
- this reintro's the multiple file support with the correct fields