### PR TITLE
The source PDF for the IT changed. Update the length test.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -44,7 +44,7 @@ func TestIntegration(t *testing.T) {
 		t.Fatalf("Got wrong content type for PDF!")
 	}
 
-	if resp.Header.Get("Content-Length") != "1024793" {
+	if resp.Header.Get("Content-Length") != "1035596" {
 		t.Fatalf("Didn't get expected content length for pdf file")
 	}
 }


### PR DESCRIPTION
This is the PDF used in the IT: https://dash.harvard.edu/bitstream/1/12285462/1/Nanometer-Scale%20Thermometry.pdf

As far as I can tell it just changed. When it is uploaded and then retrieved by the download service, the identical PDF is recreated. 

In order to test
```
docker-compose-up -d
go test -tags=integration ./...
```